### PR TITLE
Use oraclejdk8 instead of openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ rvm:
   - 2.2
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 env:
   - TEST_SUITE=unit


### PR DESCRIPTION
oraclejdk8 is recommended jdk https://github.com/travis-ci/travis-ci/issues/1647#issuecomment-28983529

This should fix the build if nothing else fails :sweat_smile: 